### PR TITLE
Add pewpew

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ HTTP(S) Benchmark Tools
 * [__lor-axe__](https://github.com/ajmwagar/lor-axe) – A multi-threaded, low-bandwidth HTTP Slowloris DoS tool that handles connections and sockets in parallel, written in `Rust`
 * [__mgun__](https://github.com/byorty/mgun) – A modern tool for load testing HTTP servers, written in Go (`golang`)
 * [__oha__](https://github.com/hatoo/oha) – HTTP load generator, inspired by rakyll/hey with tui animation, written in `Rust`
+* [__pewpew__](https://github.com/bengadbois/pewpew) - Flexible HTTP command line stress testing tool for websites and web services, written in Go (`golang`)
 * [__plow__](https://github.com/six-ddc/plow) – A high-performance HTTP benchmarking tool with real-time web UI and terminal displaying, written in Go (`golang`)
 * [__pounce__](https://github.com/fredrikwidlund/pounce) – event-driven with a similar interface as `wrk` but with the ambition to potentially achieve lower latency and higher throughout, written in `C`
 * [__rewrk__](https://github.com/ChillFish8/rewrk) – A more modern http framework benchmarker supporting HTTP/1 and HTTP/2 benchmarks, written in `Rust`.


### PR DESCRIPTION
Add [pewpew](https://github.com/bengadbois/pewpew) - a flexible HTTP command line stress testing tool for websites and web services, written in Go.