### PR TITLE
Add pywrkr

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ HTTP(S) Benchmark Tools
 * [__pewpew__](https://github.com/bengadbois/pewpew) - Flexible HTTP command line stress testing tool for websites and web services, written in Go (`golang`)
 * [__plow__](https://github.com/six-ddc/plow) – A high-performance HTTP benchmarking tool with real-time web UI and terminal displaying, written in Go (`golang`)
 * [__pounce__](https://github.com/fredrikwidlund/pounce) – event-driven with a similar interface as `wrk` but with the ambition to potentially achieve lower latency and higher throughout, written in `C`
+* [__pywrkr__](https://github.com/kurok/pywrkr) – `ab`/`wrk`-inspired benchmarking CLI with latency percentiles, virtual-user simulation, rate limiting, traffic profiles, HAR import, and SLO/threshold checks for CI, written in `Python`
 * [__RapidAPI (Paw)__](https://paw.cloud/) - for Mac is a full-featured HTTP client that lets you test and describe the APIs you build or consume.
 * [__rewrk__](https://github.com/ChillFish8/rewrk) – A more modern http framework benchmarker supporting HTTP/1 and HTTP/2 benchmarks, written in `Rust`.
 * [__reqstress__](https://github.com/utkusen/reqstress) – a benchmarking&stressing tool that can send raw HTTP requests, written in Go (`golang`).


### PR DESCRIPTION
Adds [pywrkr](https://github.com/kurok/pywrkr) to the HTTP(S) Benchmark Tools list (alphabetically, after `pounce`).

pywrkr is an `ab`/`wrk`-inspired HTTP benchmarking CLI written in Python (MIT, [on PyPI](https://pypi.org/project/pywrkr/)). It reports latency percentiles (p50–p99.99), histograms and a throughput timeline, and adds virtual-user simulation, constant-rate and traffic-profile load shaping, HAR-file import, and pass/fail SLO thresholds for CI. Entry follows the existing `[__name__](url) – description, written in \`Language\`` format.